### PR TITLE
Clarification regarding used meters for energy limits vs. pv charging

### DIFF
--- a/docs.warp-charger.com/docs/mqtt_http/api_reference/evse.mdx
+++ b/docs.warp-charger.com/docs/mqtt_http/api_reference/evse.mdx
@@ -2224,7 +2224,12 @@ Stoppt ein Ladeprotokoll. Siehe [`evse/start_debug`](/mqtt_http/api_reference/ev
 ## `evse/meter_config` {#evse_meter_config_warp1}
 
 
-Gibt an, welcher Stromzähler für Berechnungen im Zusammenhang mit Ladevorgängen verwendet werden soll. (z.B. Ladetracker, Ladelimits, usw.)
+Gibt an, welcher Stromzähler die Werte der WARP Wallbox selbst misst. Diese Daten werden für Berechnungen im Zusammenhang mit Ladevorgängen verwendet, z.B.
+Ladetracker, Ladelimits, usw.
+
+**Anmerkung:** Für das PV-Überschussladen muss ein anderer Zähler genutzt werden, der die Werte am Hausanschlusspunkt misst. Die ID dieses Zählers wird nicht
+hier, sondern im Attribut `meter_slot_grid_power` in [`power_manager/config`](/mqtt_http/api_reference/power_manager#power_manager_config_warp1) gesetzt.
+
 :::info[Beispiel]
     <Tabs groupId="apiType" queryString className="hidden-tabs">
         <TabItem value="http" label="HTTP (curl)">


### PR DESCRIPTION
Der Wortlaut "Stromzähler für Berechnungen im Zusammenhang mit Ladevorgängen" ist sehr allgemein und wäre im Grunde auch für PV-Laden gültig. Daher hat mich die Formulierung maximal verwirrt, auch da mir nicht genau klar war, was genau bei "Ladelimit" eigentlich limitiert wird (auch das könnte man ohne Hintergrundwissen in Bezug zum PV-Laden bringen). Falls es anderen ähnlich geht, könnte ihnen die vorgeschlagene Formulierung evtl. zum Verständnis behilflich sein. 