### PR TITLE
Update evcc.md

### DIFF
--- a/docs.warp-charger.com/docs/smart_home/evcc.md
+++ b/docs.warp-charger.com/docs/smart_home/evcc.md
@@ -24,7 +24,7 @@ Raspberry Pi Imager
 
 Du kannst jetzt die Micro-SD-Karte in den Raspberry Pi einlegen und ihn booten. Nachdem du dich gegebenenfalls eingeloggt hast (per SSH auf `pi@raspberry`, oder in der Textkonsole als `pi`; Passwort ist jeweils `raspberrypi`), solltest du zunächst, falls du die graphische Oberfläche gebootet hast, dem Einrichtungs-Wizard folgen. In beiden Fällen solltest du danach in der Konsole mit `sudo apt update` und `sudo apt upgrade` das System aktualisieren. Danach kannst du den Pi mit `sudo reboot` neustarten.
 
-### Verknüpfen des WARP Chargers über die HTTP-API ab EVCC Version >= 300.9
+### Verknüpfen des WARP Chargers über die HTTP-API ab EVCC Version >= 301.0
 
 Im Webinterface von EVCC muss in der Konfiguration (Laden & Heizen) / Wallbox nun nichts weiter eingegeben werden als die IP-Adresse oder der mDNS Hostname.
 


### PR DESCRIPTION
Mit dem kommenden Pull-Request (https://github.com/evcc-io/evcc/pull/26334) wird nun anstatt von MQTT die HTTP-API genutzt, was eine Einbindung in EVCC sehr viel komfortabler macht.

Gleichzeitig ist die Konfiguration über YAML nicht mehr nötig, sondern die Konfiguration über die Weboberfläche ist mit Version 0.300 Standard.

<img width="430" height="807" alt="evcc_wallbox" src="https://github.com/user-attachments/assets/480db142-bd3f-419c-8b39-5f104c45975f" />
